### PR TITLE
hotfix: lnaddress are broken

### DIFF
--- a/lnurl.py
+++ b/lnurl.py
@@ -39,7 +39,7 @@ async def api_lnurl_callback(
     link_id,
     amount: int = Query(...),
     webhook_data: str = Query(None),
-    lnaddress=False,
+    lnaddress: bool = False,
 ):
     link = await increment_pay_link(link_id, served_pr=1)
     if not link:
@@ -152,6 +152,7 @@ async def api_lnurl_response(
             request.url_for(
                 "lnurlp.api_lnurl_lnaddr_callback",
                 link_id=link.id,
+                webhook_data=webhook_data,
             )
         )
     else:
@@ -159,11 +160,9 @@ async def api_lnurl_response(
             request.url_for(
                 "lnurlp.api_lnurl_callback",
                 link_id=link.id,
+                webhook_data=webhook_data,
             )
         )
-
-    if webhook_data:
-        callback += f"?webhook_data={webhook_data}"
 
     resp = LnurlPayResponse(
         callback=callback,


### PR DESCRIPTION
lnurl validation error.
```
pydantic.error_wrappers.ValidationError: 2 validation errors for LnurlPayResponse
callback
  URL invalid, extra characters found after valid URL: ' extra={}' (type=value_error.url.extra; extra= extra={})
callback
  URL invalid, extra characters found after valid URL: ' extra={}' (type=value_error.url.extra; extra= extra={})
2023-11-24 12:54:05.36 | ERROR | lnbits.app:exception_handler:467 | Exception: 2 validation errors for LnurlPayResponse
callback
  URL invalid, extra characters found after valid URL: ' extra={}' (type=value_error.url.extra; extra= extra={})
callback
  URL invalid, extra characters found after valid URL: ' extra={}' (type=value_error.url.extra; extra= extra={})
2023-11-24 12:54:05.36 | INFO | 52.57.61.135:0 - "GET /lnurlp/api/v1/well-known/test HTTP/1.1" 500
```