### PR TITLE
refactor: do not validate username inside crud

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -5,7 +5,6 @@ from lnbits.helpers import urlsafe_short_hash, insert_query, update_query
 from . import db
 from .models import CreatePayLinkData, LnurlpSettings, PayLink
 from .nostr.key import PrivateKey
-from .services import check_lnaddress_format
 
 
 async def get_or_create_lnurlp_settings() -> LnurlpSettings:
@@ -33,21 +32,13 @@ async def delete_lnurlp_settings() -> None:
     await db.execute("DELETE FROM lnurlp.settings")
 
 
-async def check_lnaddress_not_exists(username: str) -> bool:
-    # check if lnaddress username exists in the database when creating a new entry
-    row = await db.fetchall(
+async def get_pay_link_by_username(username: str) -> Optional[PayLink]:
+    return await db.fetchall(
         "SELECT username FROM lnurlp.pay_links WHERE username = ?", (username,)
     )
-    if row:
-        raise Exception("Username already exists. Try a different one.")
-    else:
-        return True
 
 
 async def create_pay_link(data: CreatePayLinkData, wallet_id: str) -> PayLink:
-    if data.username:
-        await check_lnaddress_format(data.username)
-        await check_lnaddress_not_exists(data.username)
 
     link_id = urlsafe_short_hash()[:6]
 
@@ -128,9 +119,6 @@ async def get_pay_links(wallet_ids: Union[str, List[str]]) -> List[PayLink]:
 
 
 async def update_pay_link(link_id: str, **kwargs) -> Optional[PayLink]:
-    if "username" in kwargs and len(kwargs["username"] or "") > 0:
-        await check_lnaddress_format(kwargs["username"])
-        await check_lnaddress_not_exists(kwargs["username"])
 
     q = ", ".join([f"{field[0]} = ?" for field in kwargs.items()])
     await db.execute(

--- a/crud.py
+++ b/crud.py
@@ -33,9 +33,10 @@ async def delete_lnurlp_settings() -> None:
 
 
 async def get_pay_link_by_username(username: str) -> Optional[PayLink]:
-    return await db.fetchall(
+    row = await db.fetchone(
         "SELECT username FROM lnurlp.pay_links WHERE username = ?", (username,)
     )
+    return PayLink.from_row(row) if row else None
 
 
 async def create_pay_link(data: CreatePayLinkData, wallet_id: str) -> PayLink:

--- a/crud.py
+++ b/crud.py
@@ -34,7 +34,7 @@ async def delete_lnurlp_settings() -> None:
 
 async def get_pay_link_by_username(username: str) -> Optional[PayLink]:
     row = await db.fetchone(
-        "SELECT username FROM lnurlp.pay_links WHERE username = ?", (username,)
+        "SELECT * FROM lnurlp.pay_links WHERE username = ?", (username,)
     )
     return PayLink.from_row(row) if row else None
 

--- a/views_api.py
+++ b/views_api.py
@@ -18,10 +18,12 @@ from .crud import (
     get_address_data,
     get_or_create_lnurlp_settings,
     get_pay_link,
+    get_pay_link_by_username,
     get_pay_links,
     update_lnurlp_settings,
     update_pay_link,
 )
+from .services import check_lnaddress_format
 from .helpers import parse_nostr_private_key
 from .lnurl import api_lnurl_response
 from .models import CreatePayLinkData, LnurlpSettings
@@ -84,6 +86,14 @@ async def api_link_retrieve(
     return {**link.dict(), **{"lnurl": link.lnurl(r)}}
 
 
+async def check_username_exists(username: str):
+    prev_link = await get_pay_link_by_username(username)
+    if prev_link:
+        raise HTTPException(
+            detail="Username already taken.",
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
 @lnurlp_ext.post("/api/v1/links", status_code=HTTPStatus.CREATED)
 @lnurlp_ext.put("/api/v1/links/{link_id}", status_code=HTTPStatus.OK)
 async def api_link_create_or_update(
@@ -134,6 +144,14 @@ async def api_link_create_or_update(
             status_code=HTTPStatus.BAD_REQUEST,
         )
 
+    if data.username:
+        try:
+            await check_lnaddress_format(data.username)
+        except AssertionError as ex:
+            raise HTTPException(
+                detail=f"Invalid username: {ex}", status_code=HTTPStatus.BAD_REQUEST
+            )
+
     if link_id:
         link = await get_pay_link(link_id)
 
@@ -147,9 +165,16 @@ async def api_link_create_or_update(
                 detail="Not your pay link.", status_code=HTTPStatus.FORBIDDEN
             )
 
+        if data.username and data.username != link.username:
+            await check_username_exists(data.username)
+
         link = await update_pay_link(**data.dict(), link_id=link_id)
     else:
+        if data.username:
+            await check_username_exists(data.username)
+
         link = await create_pay_link(data, wallet_id=wallet.wallet.id)
+
     assert link
     return {**link.dict(), "lnurl": link.lnurl(request)}
 


### PR DESCRIPTION
closes #38 

check username on api level not inside crud. adds better error reporting for the api user also in frontend