### PR TITLE
Fixed Description Hash Issue on Opennode

### DIFF
--- a/lnurl.py
+++ b/lnurl.py
@@ -92,7 +92,7 @@ async def api_lnurl_callback(
         wallet_id=link.wallet,
         amount=int(amount / 1000),
         memo=link.description,
-        unhashed_description=unhashed_description,
+        unhashed_description=None,
         extra=extra,
     )
 

--- a/lnurl.py
+++ b/lnurl.py
@@ -7,7 +7,7 @@ from starlette.exceptions import HTTPException
 
 from lnbits.core.services import create_invoice
 from lnbits.utils.exchange_rates import get_fiat_rate_satoshis
-
+from lnbits.wallets import get_funding_source
 from . import lnurlp_ext
 from .crud import (
     get_or_create_lnurlp_settings,
@@ -92,7 +92,7 @@ async def api_lnurl_callback(
         wallet_id=link.wallet,
         amount=int(amount / 1000),
         memo=link.description,
-        unhashed_description=None,
+        unhashed_description=None if get_funding_source().__class__.__name__ == "OpenNodeWallet" else unhashed_description,
         extra=extra,
     )
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "repos": [
     {
       "id": "lnurlp",
-      "organisation": "kiddokodes",
+      "organisation": "lnbits",
       "repository": "lnurlp"
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "repos": [
     {
       "id": "lnurlp",
-      "organisation": "lnbits",
+      "organisation": "kiddokodes",
       "repository": "lnurlp"
     }
   ]

--- a/models.py
+++ b/models.py
@@ -106,3 +106,8 @@ class PayLink(BaseModel):
             metadata = [["text/plain", self.description]]
 
         return LnurlPayMetadata(json.dumps(metadata))
+
+
+
+class PayLnurlWData(BaseModel):
+    lnurl: str

--- a/tasks.py
+++ b/tasks.py
@@ -24,10 +24,12 @@ async def wait_for_paid_invoices():
 
     while True:
         payment = await invoice_queue.get()
+
         await on_invoice_paid(payment)
 
 
 async def on_invoice_paid(payment: Payment):
+
     if payment.extra.get("tag") != "lnurlp":
         return
 


### PR DESCRIPTION
LNURLP transactions currently do not work with opennode due to description hash error. I added a conditional check to pass description hash only if the funding source is not OpenNode

