### PR TITLE
fix: do not return early

### DIFF
--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -115,7 +115,7 @@ async def api_lnurl_callback(
             str(link.success_url),
         )
         desc = parse_obj_as(Max144Str, link.success_text)
-        return UrlAction(url=url, description=desc)
+        action = UrlAction(url=url, description=desc)
     elif link.success_text:
         message = parse_obj_as(Max144Str, link.success_text)
         action = MessageAction(message=message)

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -108,7 +108,7 @@ async def api_lnurl_callback(
         extra=extra,
     )
 
-    action = None
+    action: Optional[Union[MessageAction, UrlAction]] = None
     if link.success_url:
         url = parse_obj_as(
             Union[DebugUrl, OnionUrl, ClearnetUrl],  # type: ignore


### PR DESCRIPTION
Suspect for failing here: https://github.com/lnbits/lnbits/pull/2669

Introduced with code quality PR: 
  - https://github.com/lnbits/lnurlp/pull/59
  - commit https://github.com/lnbits/lnurlp/commit/badc4200698441fec907f15f835bdbaa78728cb7

In the current (faulty) implementation on the `if link.success_url` branch the action is returned (instead of the`LnurlPayActionResponse` which includes the `pr` field.