### PR TITLE
Allow insecure http for advanced users

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -14,7 +14,7 @@ async def get_or_create_lnurlp_settings() -> LnurlpSettings:
     if row:
         return LnurlpSettings(**row)
     else:
-        settings = LnurlpSettings(nostr_private_key=PrivateKey().hex())
+        settings = LnurlpSettings(nostr_private_key=PrivateKey().hex(),allow_insecure_http=False)
         await db.execute(
             insert_query("lnurlp.settings", settings), (*settings.dict().values(),)
         )

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "repos": [
     {
       "id": "lnurlp",
-      "organisation": "lnbits",
+      "organisation": "oren-z0",
       "repository": "lnurlp"
     }
   ]

--- a/migrations.py
+++ b/migrations.py
@@ -174,3 +174,13 @@ async def m009_add_settings(db):
         );
         """
     )
+
+async def m010_add_allow_insecure_http_to_settings(db):
+    """
+    Add extension settings table
+    """
+    await db.execute(
+        """
+        ALTER TABLE lnurlp.settings ADD COLUMN allow_insecure_http BOOLEAN;
+        """
+    )

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -36,6 +36,11 @@ new Vue({
           type: 'str',
           description: 'Nostr private key used to zap',
           name: 'nostr_private_key'
+        },
+        {
+          type: 'bool',
+          description: 'Allow insecure http: advance usage only, local domain names encoded in lightning-addresses and lnurls may be broken, and communication may be insecure.',
+          name: 'allow_insecure_http'
         }
       ],
       domain: window.location.host,

--- a/views.py
+++ b/views.py
@@ -8,7 +8,7 @@ from lnbits.helpers import template_renderer
 from starlette.exceptions import HTTPException
 from starlette.responses import HTMLResponse
 
-from .crud import get_pay_link
+from .crud import get_pay_link, get_or_create_lnurlp_settings
 
 lnurlp_generic_router = APIRouter()
 
@@ -34,7 +34,8 @@ async def display(request: Request, link_id):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Pay link does not exist."
         )
-    ctx = {"request": request, "lnurl": link.lnurl(req=request)}
+    settings = await get_or_create_lnurlp_settings()
+    ctx = {"request": request, "lnurl": link.lnurl(req=request, allow_insecure_http=settings.allow_insecure_http)}
     return lnurlp_renderer().TemplateResponse("lnurlp/display.html", ctx)
 
 
@@ -45,5 +46,6 @@ async def print_qr(request: Request, link_id):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Pay link does not exist."
         )
-    ctx = {"request": request, "lnurl": link.lnurl(req=request)}
+    settings = await get_or_create_lnurlp_settings()
+    ctx = {"request": request, "lnurl": link.lnurl(req=request, allow_insecure_http=settings.allow_insecure_http)}
     return lnurlp_renderer().TemplateResponse("lnurlp/print_qr.html", ctx)

--- a/views_api.py
+++ b/views_api.py
@@ -51,8 +51,9 @@ async def api_links(
         wallet_ids = user.wallet_ids if user else []
 
     try:
+        settings = await get_or_create_lnurlp_settings()
         return [
-            {**link.dict(), "lnurl": link.lnurl(req)}
+            {**link.dict(), "lnurl": link.lnurl(req, settings.allow_insecure_http)}
             for link in await get_pay_links(wallet_ids)
         ]
 
@@ -87,7 +88,8 @@ async def api_link_retrieve(
             detail="Not your pay link.", status_code=HTTPStatus.FORBIDDEN
         )
 
-    return {**link.dict(), **{"lnurl": link.lnurl(r)}}
+    settings = await get_or_create_lnurlp_settings()
+    return {**link.dict(), **{"lnurl": link.lnurl(r, settings.allow_insecure_http)}}
 
 
 async def check_username_exists(username: str):
@@ -197,7 +199,8 @@ async def api_link_create_or_update(
         link = await create_pay_link(data)
 
     assert link
-    return {**link.dict(), "lnurl": link.lnurl(request)}
+    settings = await get_or_create_lnurlp_settings()
+    return {**link.dict(), "lnurl": link.lnurl(request, settings.allow_insecure_http)}
 
 
 @lnurlp_api_router.delete("/api/v1/links/{link_id}", status_code=HTTPStatus.OK)

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -24,7 +24,8 @@ from .crud import (
 )
 
 class InsecureClearnetUrl(Url):
-    allowed_schemes = {"http"}
+    tld_required = False
+    allowed_schemes = {"http", "https"}
 
 lnurlp_lnurl_router = APIRouter()
 

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -30,6 +30,7 @@ class InsecureClearnetUrl(Url):
 class InsecureLnurlPayResponse(LnurlPayResponse):
     callback: Union[ClearnetUrl, OnionUrl, DebugUrl, InsecureClearnetUrl]
 
+
 lnurlp_lnurl_router = APIRouter()
 
 

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -27,6 +27,9 @@ class InsecureClearnetUrl(Url):
     tld_required = False
     allowed_schemes = {"http", "https"}
 
+class InsecureLnurlPayResponse(LnurlPayResponse):
+    callback: Union[ClearnetUrl, OnionUrl, DebugUrl, InsecureClearnetUrl]
+
 lnurlp_lnurl_router = APIRouter()
 
 
@@ -162,12 +165,20 @@ async def api_lnurl_response(
         str(url),
     )
 
-    resp = LnurlPayResponse(
-        callback=callback_url,
-        minSendable=MilliSatoshi(round(link.min * rate) * 1000),
-        maxSendable=MilliSatoshi(round(link.max * rate) * 1000),
-        metadata=link.lnurlpay_metadata,
-    )
+    if settings.allow_insecure_http:
+        resp = InsecureLnurlPayResponse(
+            callback=callback_url,
+            minSendable=MilliSatoshi(round(link.min * rate) * 1000),
+            maxSendable=MilliSatoshi(round(link.max * rate) * 1000),
+            metadata=link.lnurlpay_metadata,
+        )
+    else:
+        resp = LnurlPayResponse(
+            callback=callback_url,
+            minSendable=MilliSatoshi(round(link.min * rate) * 1000),
+            maxSendable=MilliSatoshi(round(link.max * rate) * 1000),
+            metadata=link.lnurlpay_metadata,
+        )
     params = resp.dict()
 
     if link.comment_chars > 0:


### PR DESCRIPTION
I've forked v0.5.6 (My Umbrel can't run v1.0.0) and added a checkbox to allow insecure http (instead of https).
This is useful for advanced home-node operators that open their LNBits to the web in complicated routing schemes, i.e. ngrok or Holesail. In these cases the routed request might not be an https request.

Obviously if the operator access LNBits from a different domain than the his final users (i.e. localhost) he should be aware that the lnurls and lightning-addresses encode the wrong domain. Again, this is for advanced operators.

Feel free to test by adding https://raw.githubusercontent.com/oren-z0/lnurlp/allow-insecure-http/manifest.json to your Extension Sources.