### PR TITLE
[DRAFT] Fix: Allow localhost LNURLP addresses with warnings (#83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 node_modules
 .mypy_cache
 .venv
+/data
+/pgdata

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Docker Development Environment
+- `docker compose up -d` - Start development environment (LNbits on port 5002)
+- `docker compose logs -f` - View container logs
+- `docker compose down` - Stop development environment
+- `docker compose exec lnurlp-lnbits-dev bash` - Access container shell
+
+### Code Quality
+- `make format` - Format all code (Python with black/ruff, JS with prettier)
+- `make check` - Run all checks (mypy, pyright, linting)
+- `make test` - Run pytest tests
+- `make pre-commit` - Run pre-commit hooks
+
+### Individual Tools
+- `poetry run black .` - Format Python code
+- `poetry run ruff check . --fix` - Lint Python with fixes
+- `poetry run mypy .` - Type check Python
+- `poetry run pyright` - Additional type checking
+- `poetry run pytest` - Run tests
+
+## Architecture Overview
+
+LNURLp is an LNbits extension for creating static Lightning payment links. Key architectural points:
+
+### Backend Structure
+- **models.py**: Pydantic models define PayLink, CreatePayLinkData, and settings schemas
+- **crud.py**: Database operations using LNbits' abstraction layer
+- **views_lnurl.py**: LNURL protocol endpoints handle payment flow
+- **views_api.py**: REST API for link management
+- **tasks.py**: Background payment processing with webhook support
+- **nostr/**: Nostr zaps integration module
+
+### Frontend
+- **static/js/index.js**: Vue.js 3 + Quasar UI application
+- Templates use Jinja2 with LNbits base templates
+
+### Key Flows
+1. Payment links store configuration in database with unique IDs
+2. LNURL endpoints generate invoices dynamically based on link settings
+3. Webhooks notify external services of payments
+4. Nostr integration enables zaps through NIP-57 events
+
+### Database Schema
+Pay links table includes: wallet, description, amount settings, currency, webhooks, success messages, and Nostr metadata. Uses LNbits migration system.
+
+## Extension Integration
+
+This follows LNbits extension patterns:
+- Registered via __init__.py blueprint
+- Uses LNbits database, wallet, and settings abstractions
+- Integrates with LNbits authentication and UI framework
+- Supports multi-wallet functionality

--- a/README.md
+++ b/README.md
@@ -6,6 +6,41 @@
 
 LNURL is a range of lightning-network standards that allow us to use lightning-network differently. An LNURL-pay is a link that wallets use to fetch an invoice from a server on-demand. The link or QR code is fixed, but each time it is read by a compatible wallet a new invoice is issued by the service and sent to the wallet.
 
+## Development Setup
+
+### Docker Development Environment
+
+For local development and testing, you can use the included Docker Compose setup:
+
+```bash
+# Start the development environment
+docker compose up -d
+
+# Access LNbits at http://localhost:5002
+# View logs
+docker compose logs -f
+
+# Stop the environment
+docker compose down
+```
+
+This setup includes:
+- LNbits with the LNURLP extension mounted for development
+- PostgreSQL database for persistence
+- FakeWallet backend for testing payments
+- Port 5002 to avoid conflicts with other services
+
+### Localhost and HTTP Support
+
+This extension supports localhost and HTTP addresses for development purposes. When creating LNURL pay links on non-HTTPS or local addresses, you'll see warning messages explaining the limitations:
+
+- **Localhost addresses** (`localhost`, `127.0.0.1`) will only work locally
+- **Internal IP addresses** (`192.168.x.x`, `10.x.x.x`) will only work within your local network  
+- **HTTP addresses** may not work with most wallets (HTTPS recommended)
+- **Tor onion addresses** work with both HTTP and HTTPS
+
+For production use, always use HTTPS or Tor onion addresses for maximum wallet compatibility.
+
 [**Wallets supporting LNURL**](https://github.com/fiatjaf/awesome-lnurl#wallets)
 
 ## Usage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  lnurlp-lnbits-dev:
+    image: lnbits/lnbits:latest
+    container_name: lnurlp-lnbits-dev
+    restart: unless-stopped
+    ports:
+      - "5002:5000"
+    environment:
+      - LNBITS_BACKEND_WALLET_CLASS=FakeWallet
+      - LNBITS_ADMIN_UI=true
+      - LNBITS_DATA_FOLDER=/app/data
+      - LNBITS_DATABASE_URL=postgres://lnbits:password@lnurlp-postgres:5432/lnbits
+      - PYTHONDONTWRITEBYTECODE=1  # Prevent Python from writing .pyc files
+      - PYTHONUNBUFFERED=1         # Ensure Python output is not buffered
+    volumes:
+      - ./data:/app/data
+      # Override the built-in lnurlp extension with our development version
+      - .:/app/lnbits/extensions/lnurlp
+    depends_on:
+      - lnurlp-postgres
+    networks:
+      - lnbits-network
+
+  lnurlp-postgres:
+    image: postgres:15
+    container_name: lnurlp-postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=lnbits
+      - POSTGRES_USER=lnbits
+      - POSTGRES_PASSWORD=password
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+    networks:
+      - lnbits-network
+
+networks:
+  lnbits-network:
+    driver: bridge
+
+volumes:
+  pgdata:
+  data:

--- a/helpers.py
+++ b/helpers.py
@@ -1,3 +1,7 @@
+import ipaddress
+from typing import Tuple
+from urllib.parse import urlparse
+
 from .nostr.key import PrivateKey
 
 
@@ -6,3 +10,44 @@ def parse_nostr_private_key(key: str) -> PrivateKey:
         return PrivateKey.from_nsec(key)
     else:
         return PrivateKey(bytes.fromhex(key))
+
+
+def is_localhost_or_internal_url(url: str) -> Tuple[bool, str]:
+    """
+    Check if a URL is localhost, internal IP, or non-HTTPS.
+    Returns (is_unsafe, warning_message)
+    """
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        scheme = parsed.scheme.lower()
+        
+        # Tor onion addresses are allowed with HTTP
+        if host.endswith(".onion"):
+            return False, ""
+        
+        # Check if it's not HTTPS
+        if scheme != "https":
+            # Check for localhost variations
+            if host in ["localhost", "127.0.0.1", "::1"]:
+                return True, "Localhost addresses are only accessible from the same machine and may not work with all wallets"
+            
+            # Check for internal/private IP addresses
+            try:
+                ip = ipaddress.ip_address(host)
+                if ip.is_private:
+                    return True, f"Internal IP address {host} is only accessible within your local network and may not work with external wallets"
+            except ValueError:
+                # Not an IP address, could be a domain
+                pass
+            
+            # Check for .local domains (common in internal networks)
+            if host.endswith(".local"):
+                return True, f"{host} appears to be a local network address and may not work with external wallets"
+            
+            # General HTTP warning
+            return True, "HTTP addresses are not secure and may not work with most wallets. HTTPS or Tor onion addresses are recommended"
+            
+        return False, ""
+    except Exception:
+        return False, ""

--- a/templates/lnurlp/index.html
+++ b/templates/lnurlp/index.html
@@ -154,6 +154,13 @@
   <q-dialog v-model="formDialog.show" @hide="closeFormDialog">
     <q-card class="q-pa-lg q-pt-xl lnbits__dialog-card">
       <q-form @submit="sendFormData" class="q-gutter-md">
+        <!-- Warning banner for non-HTTPS/non-Tor URLs -->
+        <q-banner v-if="showUrlWarning" class="text-white bg-orange" rounded>
+          <template v-slot:avatar>
+            <q-icon name="warning" color="white" />
+          </template>
+          <span v-text="urlWarningMessage"></span>
+        </q-banner>
         <q-select
           filled
           dense

--- a/templates/lnurlp/index.html
+++ b/templates/lnurlp/index.html
@@ -137,8 +137,20 @@
     <q-card>
       <q-card-section>
         <h6 class="text-subtitle1 q-my-none">
-          {{ SITE_TITLE }} LNURL-pay extension
+          Pay Links Extension
         </h6>
+      </q-card-section>
+      <q-card-section class="q-pa-md">
+        <p class="text-body2 q-mb-sm">
+          This extension creates static payment links using the LNURL-p (Lightning Network URL Pay) protocol. 
+          Unlike traditional Lightning invoices that expire and can only be used once, LNURL-p enables 
+          reusable payment identifiers that work like email addresses for Bitcoin payments.
+        </p>
+        <p class="text-body2 q-mb-none">
+          <strong>Note:</strong> Not all Lightning wallets support LNURL-p protocols. Additionally, 
+          Tor onion addresses may have limited compatibility with some mobile wallets, though they 
+          work well with most desktop Lightning implementations.
+        </p>
       </q-card-section>
       <q-card-section class="q-pa-none">
         <q-separator></q-separator>


### PR DESCRIPTION
## Summary
Fixes #83 by allowing localhost and non-HTTPS LNURLP addresses while providing appropriate warnings to users.

![photo_2025-06-16_02-06-20](https://github.com/user-attachments/assets/83ef7560-ce66-4c74-860e-5ad281abdfe5)

## Changes
✅ Remove strict HTTPS/Tor requirements for LNURL creation
✅ Add comprehensive warning system for non-HTTPS URLs
✅ Support localhost, internal IPs, and HTTP addresses with warnings
✅ Display warning banners in form dialogs for unsafe connections
✅ Show toast notifications when creating links with warnings
✅ Custom LNURL encoding fallback for non-standard URLs
✅ Maintain existing security for HTTPS and Tor onion addresses
✅ Update UI with better extension title and LNURL-p description
✅ Add Docker development environment with PostgreSQL

## Testing Needed
- [x] Test localhost addresses (localhost)
- [ ] Test localhost addresses (127.0.0.1)
- [ ] Test internal IP addresses (192.168.x.x, 10.x.x.x)
- [ ] Test HTTP vs HTTPS behavior
- [ ] Test Tor onion addresses
- [ ] Test warning messages display correctly
- [ ] Test wallet compatibility with generated LNURLs

## Docker Testing
```bash
docker compose up -d
# Access at http://localhost:5002
```

## Notes
This is a **DRAFT** PR for code review and testing. The author needs to fully review Claude's code and test over HTTPS/IP addresses before marking as ready for review.