### PR TITLE
feat: return `PayLink` model on API endpoint removes `lnurl`

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,9 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import Query, Request
-from lnbits.helpers import normalize_path
-from lnurl import encode as lnurl_encode
+from fastapi import Query
 from pydantic import BaseModel, Field
 
 from .helpers import parse_nostr_private_key
@@ -62,14 +60,6 @@ class PayLink(BaseModel):
     fiat_base_multiplier: int | None = None
 
     disposable: bool
+
     # TODO deprecated, unused in the code, should be deleted from db.
     domain: Optional[str] = None
-
-    def lnurl(self, req: Request) -> str:
-        url = req.url_for("lnurlp.api_lnurl_response", link_id=self.id)
-        url = url.replace(path=normalize_path(url.path))
-        url_str = str(url)
-        if url.netloc.endswith(".onion"):
-            # change url string scheme to http
-            url_str = url_str.replace("https://", "http://")
-        return lnurl_encode(url_str)

--- a/templates/lnurlp/print_qr.html
+++ b/templates/lnurlp/print_qr.html
@@ -1,7 +1,7 @@
 {% extends "print.html" %} {% block page %}
 <div class="row justify-center">
   <div class="qr">
-    <lnbits-qrcode value="lightning:{{ lnurl }}"></lnbits-qrcode>
+    <lnbits-qrcode :value="lnurl"></lnbits-qrcode>
   </div>
 </div>
 {% endblock %} {% block styles %}
@@ -15,10 +15,16 @@
   window.app = Vue.createApp({
     el: '#vue',
     created() {
+      const url = window.location.origin + '/lnurlp/{{ link_id }}'
+      const bytes = new TextEncoder().encode(url)
+      const bech32 = NostrTools.nip19.encodeBytes('lnurl', bytes)
+      this.lnurl = `lightning:${bech32.toUpperCase()}`
       window.print()
     },
     data() {
-      return {width: window.innerWidth * 0.5}
+      return {
+        width: window.innerWidth * 0.5
+      }
     }
   })
 </script>

--- a/views.py
+++ b/views.py
@@ -41,5 +41,5 @@ async def print_qr(request: Request, link_id):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Pay link does not exist."
         )
-    ctx = {"request": request, "lnurl": link.lnurl(req=request)}
+    ctx = {"request": request, "link_id": link.id}
     return lnurlp_renderer().TemplateResponse("lnurlp/print_qr.html", ctx)


### PR DESCRIPTION
remove the `lnurl` key from the responses, as they can easily be generated on the client side with `${domain}/lnurlp/${link.id}` and if even needed encoded to bech32 or lud17. that was already the case on the frontend after https://github.com/lnbits/lnurlp/pull/89

```js
      const url = window.location.origin + '/lnurlp/{{ link_id }}'
      // lud17
      const lnurl = url.replace("https", "lnurlp")
      // bech32
      const bytes = new TextEncoder().encode(url)
      const bech32 = NostrTools.nip19.encodeBytes('lnurl', bytes)
      const lnurl = `lightning:${bech32.touppercase()}`
```