### PR TITLE
Fix: Use Annotated syntax for webhook_data Query parameter

### DIFF
--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -1,5 +1,6 @@
 import json
 from http import HTTPStatus
+from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from lnbits.core.services import create_invoice
@@ -150,7 +151,9 @@ async def api_lnurl_callback(
     name="lnurlp.api_lnurl_response",
 )
 async def api_lnurl_response(
-    request: Request, link_id: str, webhook_data: str | None = Query(None)
+    request: Request,
+    link_id: str,
+    webhook_data: Annotated[str | None, Query()] = None,
 ) -> LnurlPayResponse:
     link = await get_pay_link(link_id)
     if not link:


### PR DESCRIPTION
Fixes #126

## Problem

When accessing a lightning address via , the returned callback URL contains a malformed  parameter even when no webhook is configured. This breaks LNURL-pay flows (especially Nostr zaps) because clients append  to a URL that already has query parameters, resulting in double question marks.

## Root Cause

The  parameter in  was using  as a default value. When called directly as a Python function (from ),  doesn't resolve to  - it remains a FastAPI  object which is truthy.

This caused the check `if webhook_data:` to pass, appending the string representation of the FieldInfo object to the callback URL.

## Solution  

Use `Annotated[str | None, Query()] = None` syntax which properly separates FastAPI metadata from the default value, making the function safe to call both via HTTP and directly as a Python function.

## Changes

- Added `from typing import Annotated` import
- Changed function signature from:
  ```python
  webhook_data: str | None = Query(None)
  ```
  to:
  ```python
  webhook_data: Annotated[str | None, Query()] = None
  ```

## Impact

- ✅ Fixes all lightning address zaps that were failing with 400 errors
- ✅ Maintains backward compatibility with direct HTTP calls
- ✅ No breaking changes to API

## Testing

Tested against the exact scenario described in #126:
- Lightning address queries now return clean callback URLs
- Zap flow works correctly (no double question marks)
- Regular LNURL-pay continues to work as expected