### PR TITLE
fix: remove double slash in LNURL pay endpoint URL

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -150,7 +150,7 @@ window.PageLnurlp = {
         username: link.username
       }
       const domain = link.domain || window.location.host
-      this.activeUrl = `https://${domain}/lnurlp//${link.id}`
+      this.activeUrl = `https://${domain}/lnurlp/${link.id}`
       this.qrCodeDialog.show = true
     },
     openUpdateDialog(linkId) {


### PR DESCRIPTION
Reproduction (curl)

Broken endpoint:
`curl -i "https://demo.lnbits.com/lnurlp//Lv8UTS"`
Fixed endpoint:
`curl -i "https://demo.lnbits.com/lnurlp/Lv8UTS"`